### PR TITLE
Fix 4.4 instructions

### DIFF
--- a/index.html
+++ b/index.html
@@ -338,20 +338,32 @@
 
 		<div class="code">
 			devel-su<br>
+			zypper ref<br>
+			zypper dup<br>
 			ssu re 4.4.0.58<br>
 			ssu ur<br>
 			zypper ref<br>
 			zypper dup
 		</div>
 
-		<p>Now you might be left with no network connection for all Sailjail apps. To resolve this, update the resolv.conf symlink from /var/run/connman/resolv.conf to /run/connman/resolv.conf</p>
+		<p>Reboot when you're done.</p>
+
+		<p>In case you are left with no network connection for all Sailjail apps, there are two possible culprits.</p>
+
+		<p>Dnsmasq might have wrongly been activated by the systemd update. Disable it with:</p>
 
 		<div class="code">
-			rm -f /etc/resolv.conf<br>
-			ln -s /run/connman/resolv.conf /etc/resolv.conf<br>
+			systemctl disable dnsmasq<br>
 		</div>
 
-		<p>Reboot when you're done.</p>
+		<p>Another quirk could be the resolv.conf not being visible from inside the Sailjail. Check if your /etc/resolv.conf symlink still points to /var/run/connman/resolv.conf. Change it to /run/connman/resolv.conf and restart the browser booster.</p>
+
+		<div class="code">
+			ls -l /etc/resolv.conf<br>
+			rm -f /etc/resolv.conf<br>
+			ln -s /run/connman/resolv.conf /etc/resolv.conf<br>
+			systemctl --user restart booster-browser@sailfish-browser.service<br>
+		</div>
 
 	</div>
 	<div class="card">

--- a/index.html
+++ b/index.html
@@ -395,8 +395,8 @@
 	</div>
 	<div class="card"
 		style="color: darkgray; padding-top: 5px; padding-bottom: 5px; border-left-color: white; text-align: right; border-top-left-radius: 50px; border-bottom-right-radius: 50px;">
-		<p style="padding-right: 20px">Publication date: 2022-01-08<br>Updated: 2022-04-05<br>
-		        Version: v0.2.2</p>
+		<p style="padding-right: 20px">Publication date: 2022-01-08<br>Updated: 2022-04-06<br>
+		        Version: v0.2.3</p>
 	</div>
 </body>
 


### PR DESCRIPTION
After now 5 user testings over the day, various results happened.
Leading to addition of the hint about disabling dnsmasq.
But most importantly prepending zypper ref && zypper dup to the update. So that possibly varying states of repo links are corrected to the recent ones. Effectively by first updating the 4.3 install before doing the upgrade to 4.4.
This is not Pro¹ port specific and possibly quickly resolved by Jolla.
That is why both hints regarding loss of network are reformulated into a possibility (Depending on age of the install and user error).
Since, as far as we know, after Jolla fixes the issues, both errors should only occur when the user omits the zypper ref and zypper dup before upgrading to 4.4, coming from an install with wrong repo links.